### PR TITLE
feat(cli): --format flag with a JSON Schema renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(fc-json-core STATIC
   fc.json/parse/parser.cpp
   fc.json/schema/infer.cpp
   fc.json/render/pydantic.cpp
+  fc.json/render/jsonschema.cpp
 )
 target_include_directories(fc-json-core PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
 
@@ -31,6 +32,7 @@ add_executable(fc-json-tests
   fc.json/tests/test_parser.cpp
   fc.json/tests/test_infer.cpp
   fc.json/tests/test_render.cpp
+  fc.json/tests/test_jsonschema.cpp
 )
 target_link_libraries(fc-json-tests PRIVATE doctest::doctest fc-json-core)
 add_test(NAME fc-json-tests COMMAND fc-json-tests)

--- a/fc.json/main.cpp
+++ b/fc.json/main.cpp
@@ -15,6 +15,7 @@
 #include "parse/parser.hpp"
 #include "schema/infer.hpp"
 #include "render/pydantic.hpp"
+#include "render/jsonschema.hpp"
 
 namespace {
 
@@ -40,6 +41,12 @@ int main(int argc, char* argv[]) {
         .help("json file to process")
         .store_into(filename);
 
+    std::string format;
+    parser.add_argument("-f", "--format")
+        .help("output format: pydantic (default) or json-schema")
+        .default_value(std::string("pydantic"))
+        .store_into(format);
+
     try {
         parser.parse_args(argc, argv);
     } catch (const std::exception& err) {
@@ -47,10 +54,19 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    // Validated here rather than via argparse .choices() so a bad value gets a
+    // clear message instead of argparse's misleading positional-count error.
+    if (format != "pydantic" && format != "json-schema") {
+        std::cerr << "fc.json: unknown format '" << format
+                  << "' (expected: pydantic, json-schema)\n";
+        return 1;
+    }
+
     try {
         const std::string text = readFile(filename);
         const fc::SchemaModule schema = fc::inferSchema(fc::parse(text));
-        std::cout << fc::renderPydantic(schema);
+        std::cout << (format == "json-schema" ? fc::renderJsonSchema(schema)
+                                              : fc::renderPydantic(schema));
     } catch (const std::exception& err) {
         std::cerr << "fc.json: " << err.what() << "\n";
         return 1;

--- a/fc.json/render/jsonschema.cpp
+++ b/fc.json/render/jsonschema.cpp
@@ -1,0 +1,146 @@
+#include "jsonschema.hpp"
+
+#include <string>
+#include <vector>
+
+namespace fc {
+namespace {
+
+// A JSON string literal for an arbitrary key/value. Escapes per JSON rules;
+// control characters below 0x20 use \u00XX.
+std::string jsonString(const std::string& s) {
+    static const char* hex = "0123456789abcdef";
+    std::string out = "\"";
+    for (unsigned char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            case '\b': out += "\\b"; break;
+            case '\f': out += "\\f"; break;
+            default:
+                if (c < 0x20) {
+                    out += "\\u00";
+                    out += hex[(c >> 4) & 0xF];
+                    out += hex[c & 0xF];
+                } else {
+                    out += static_cast<char>(c); // UTF-8 bytes pass through
+                }
+        }
+    }
+    return out + "\"";
+}
+
+class JsonSchemaRenderer {
+public:
+    explicit JsonSchemaRenderer(const SchemaModule& mod) : mod_(mod) {}
+
+    std::string run() {
+        std::string out = "{\n";
+        out += ind(1) + "\"$schema\": \"https://json-schema.org/draft/2020-12/schema\"";
+
+        if (!mod_.schemas.empty()) {
+            out += ",\n" + ind(1) + "\"$defs\": {\n";
+            for (std::size_t i = 0; i < mod_.schemas.size(); ++i) {
+                out += ind(2) + jsonString(mod_.schemas[i].name) + ": " +
+                       objectSchema(mod_.schemas[i], 2);
+                out += (i + 1 < mod_.schemas.size()) ? ",\n" : "\n";
+            }
+            out += ind(1) + "}";
+        }
+
+        // Splice the root type onto the top-level object so $schema/$defs stay
+        // siblings of the document type.
+        out += rootMembers();
+        out += "\n}\n";
+        return out;
+    }
+
+private:
+    const SchemaModule& mod_;
+
+    static std::string ind(int n) { return std::string(static_cast<std::size_t>(n) * 2, ' '); }
+
+    // Top-level document type, emitted as sibling members of $schema/$defs.
+    std::string rootMembers() {
+        const TypeRef& r = mod_.root;
+        switch (r.kind) {
+            case TypeKind::Object:
+                return ",\n" + ind(1) + "\"$ref\": " +
+                       jsonString("#/$defs/" + mod_.at(r.objectSchema).name);
+            case TypeKind::List:
+                return ",\n" + ind(1) + "\"type\": \"array\",\n" + ind(1) +
+                       "\"items\": " + inlineType(r.args.front(), 1);
+            case TypeKind::Null:    return ",\n" + ind(1) + "\"type\": \"null\"";
+            case TypeKind::Bool:    return ",\n" + ind(1) + "\"type\": \"boolean\"";
+            case TypeKind::Int:     return ",\n" + ind(1) + "\"type\": \"integer\"";
+            case TypeKind::Float:   return ",\n" + ind(1) + "\"type\": \"number\"";
+            case TypeKind::String:  return ",\n" + ind(1) + "\"type\": \"string\"";
+            case TypeKind::Union:   // a single JSON document value is never a union
+            case TypeKind::Unknown: return ""; // top-level accepts anything
+        }
+        return "";
+    }
+
+    // Render a named object schema: type/properties/required.
+    std::string objectSchema(const Schema& s, int depth) {
+        std::string out = "{\n";
+        out += ind(depth + 1) + "\"type\": \"object\"";
+        if (!s.fields.empty()) {
+            out += ",\n" + ind(depth + 1) + "\"properties\": {\n";
+            std::vector<std::string> required;
+            for (std::size_t i = 0; i < s.fields.size(); ++i) {
+                const Field& f = s.fields[i];
+                out += ind(depth + 2) + jsonString(f.key) + ": " + inlineType(f.type, depth + 2);
+                out += (i + 1 < s.fields.size()) ? ",\n" : "\n";
+                if (!f.optional) required.push_back(f.key);
+            }
+            out += ind(depth + 1) + "}";
+            if (!required.empty()) {
+                out += ",\n" + ind(depth + 1) + "\"required\": [";
+                for (std::size_t i = 0; i < required.size(); ++i) {
+                    if (i) out += ", ";
+                    out += jsonString(required[i]);
+                }
+                out += "]";
+            }
+        }
+        out += "\n" + ind(depth) + "}";
+        return out;
+    }
+
+    // A type as a compact JSON Schema fragment.
+    std::string inlineType(const TypeRef& t, int depth) {
+        switch (t.kind) {
+            case TypeKind::Null:    return R"({ "type": "null" })";
+            case TypeKind::Bool:    return R"({ "type": "boolean" })";
+            case TypeKind::Int:     return R"({ "type": "integer" })";
+            case TypeKind::Float:   return R"({ "type": "number" })";
+            case TypeKind::String:  return R"({ "type": "string" })";
+            case TypeKind::Unknown: return "{}"; // any
+            case TypeKind::Object:
+                return "{ \"$ref\": " + jsonString("#/$defs/" + mod_.at(t.objectSchema).name) + " }";
+            case TypeKind::List:
+                return "{ \"type\": \"array\", \"items\": " + inlineType(t.args.front(), depth) + " }";
+            case TypeKind::Union: {
+                std::string s = "{ \"anyOf\": [";
+                for (std::size_t i = 0; i < t.args.size(); ++i) {
+                    s += (i ? ", " : " ");
+                    s += inlineType(t.args[i], depth);
+                }
+                return s + " ] }";
+            }
+        }
+        return "{}";
+    }
+};
+
+} // namespace
+
+std::string renderJsonSchema(const SchemaModule& mod) {
+    return JsonSchemaRenderer(mod).run();
+}
+
+} // namespace fc

--- a/fc.json/render/jsonschema.hpp
+++ b/fc.json/render/jsonschema.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+// JSON Schema renderer: SchemaIR -> a JSON Schema (2020-12) document.
+// * Pure function over the SchemaIR. Property names are kept raw (JSON Schema
+// * allows any string key, so no identifier sanitization here, unlike the
+// * Pydantic renderer). No rapidjson: the JSON is hand-built. See ADR 0001.
+
+#include <string>
+
+#include "../ir/schema.hpp"
+
+namespace fc {
+
+std::string renderJsonSchema(const SchemaModule& mod);
+
+} // namespace fc

--- a/fc.json/tests/test_jsonschema.cpp
+++ b/fc.json/tests/test_jsonschema.cpp
@@ -1,0 +1,72 @@
+#include <doctest/doctest.h>
+
+#include <string>
+
+#include "../parse/parser.hpp"
+#include "../render/jsonschema.hpp"
+#include "../schema/infer.hpp"
+
+using namespace fc;
+
+namespace {
+
+std::string js(const std::string& json) {
+    return renderJsonSchema(inferSchema(parse(json)));
+}
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+} // namespace
+
+TEST_CASE("emits 2020-12 dialect, $defs and a root $ref") {
+    std::string out = js(R"({"i":1})");
+    CHECK(has(out, R"("$schema": "https://json-schema.org/draft/2020-12/schema")"));
+    CHECK(has(out, R"("$defs")"));
+    CHECK(has(out, R"("Root":)"));
+    CHECK(has(out, R"("$ref": "#/$defs/Root")"));
+}
+
+TEST_CASE("scalar types map to JSON Schema types") {
+    std::string out = js(R"({"i":1,"f":1.5,"s":"x","b":true,"z":null})");
+    CHECK(has(out, R"("i": { "type": "integer" })"));
+    CHECK(has(out, R"("f": { "type": "number" })"));
+    CHECK(has(out, R"("s": { "type": "string" })"));
+    CHECK(has(out, R"("b": { "type": "boolean" })"));
+    CHECK(has(out, R"("z": { "type": "null" })"));
+}
+
+TEST_CASE("required lists non-optional fields only") {
+    std::string out = js(R"({"list":[{"a":1,"b":2},{"a":1}]})");
+    // ListItem: a required, b optional
+    CHECK(has(out, R"("required": ["a"])"));
+    CHECK_FALSE(has(out, R"("required": ["a", "b"])"));
+}
+
+TEST_CASE("nested object becomes a $ref into $defs") {
+    std::string out = js(R"({"address":{"city":"x"}})");
+    CHECK(has(out, R"("Address":)"));
+    CHECK(has(out, R"("address": { "$ref": "#/$defs/Address" })"));
+}
+
+TEST_CASE("array renders items; heterogeneous renders anyOf") {
+    CHECK(has(js(R"({"xs":[1,2]})"), R"("type": "array", "items": { "type": "integer" })"));
+    std::string u = js(R"({"d":[1,"x"]})");
+    CHECK(has(u, R"("anyOf")"));
+}
+
+TEST_CASE("property names are kept raw, not sanitized (unlike pydantic)") {
+    // Key with a space is a valid JSON Schema property name verbatim; no alias.
+    std::string out = js(R"({"a b":1})");
+    CHECK(has(out, R"("a b": { "type": "integer" })"));
+    CHECK_FALSE(has(out, "alias"));
+    CHECK_FALSE(has(out, "a_b"));
+}
+
+TEST_CASE("top-level array emits an array root, not a $ref") {
+    std::string out = js(R"([{"a":1}])");
+    CHECK(has(out, R"("type": "array")"));
+    CHECK(has(out, R"("items": { "$ref": "#/$defs/RootItem" })"));
+    CHECK(has(out, R"("RootItem":)"));
+}


### PR DESCRIPTION
## Summary

- adds `-f/--format <pydantic|json-schema>`, default pydantic (bare invocation unchanged)
- new JSON Schema 2020-12 renderer over the SchemaIR

## Why

First renderer on the new spine besides pydantic, and a check that the
parse/IR/render split actually pays off. Same SchemaIR, different target rules:
JSON Schema keeps property names raw (any string key is legal there) so no
sanitization or aliases, and it stays rapidjson-free by hand-building the JSON,
keeping the parse-adapter quarantine from ADR 0001.

## Risk

Low. Default output is unchanged, so existing behavior is intact. Format is
validated explicitly (clear error, exit 1) instead of via argparse `.choices()`,
which surfaced an invalid value as a misleading positional-count error.

## Validation

- `ctest`: 38 cases / 120 assertions pass
- both samples produce valid 2020-12 schemas, and the source docs validate
  against them (python jsonschema)

## Follow-up

- example/redact renderer (PR-B), table renderer (PR-C)
- issue #8 (signature delimiter hardening) remains open, unrelated
