### PR TITLE
feat(cli): example and redact output formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(fc-json-core STATIC
   fc.json/schema/infer.cpp
   fc.json/render/pydantic.cpp
   fc.json/render/jsonschema.cpp
+  fc.json/render/document.cpp
 )
 target_include_directories(fc-json-core PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
 
@@ -33,6 +34,7 @@ add_executable(fc-json-tests
   fc.json/tests/test_infer.cpp
   fc.json/tests/test_render.cpp
   fc.json/tests/test_jsonschema.cpp
+  fc.json/tests/test_document.cpp
 )
 target_link_libraries(fc-json-tests PRIVATE doctest::doctest fc-json-core)
 add_test(NAME fc-json-tests COMMAND fc-json-tests)

--- a/fc.json/main.cpp
+++ b/fc.json/main.cpp
@@ -16,6 +16,7 @@
 #include "schema/infer.hpp"
 #include "render/pydantic.hpp"
 #include "render/jsonschema.hpp"
+#include "render/document.hpp"
 
 namespace {
 
@@ -43,7 +44,7 @@ int main(int argc, char* argv[]) {
 
     std::string format;
     parser.add_argument("-f", "--format")
-        .help("output format: pydantic (default) or json-schema")
+        .help("output format: pydantic (default), json-schema, example, redact")
         .default_value(std::string("pydantic"))
         .store_into(format);
 
@@ -56,17 +57,28 @@ int main(int argc, char* argv[]) {
 
     // Validated here rather than via argparse .choices() so a bad value gets a
     // clear message instead of argparse's misleading positional-count error.
-    if (format != "pydantic" && format != "json-schema") {
+    if (format != "pydantic" && format != "json-schema" &&
+        format != "example" && format != "redact") {
         std::cerr << "fc.json: unknown format '" << format
-                  << "' (expected: pydantic, json-schema)\n";
+                  << "' (expected: pydantic, json-schema, example, redact)\n";
         return 1;
     }
 
     try {
         const std::string text = readFile(filename);
-        const fc::SchemaModule schema = fc::inferSchema(fc::parse(text));
-        std::cout << (format == "json-schema" ? fc::renderJsonSchema(schema)
-                                              : fc::renderPydantic(schema));
+        const fc::Tree tree = fc::parse(text);
+
+        std::string output;
+        if (format == "example") {
+            output = fc::renderExample(tree);
+        } else if (format == "redact") {
+            output = fc::renderRedacted(tree);
+        } else {
+            const fc::SchemaModule schema = fc::inferSchema(tree);
+            output = (format == "json-schema") ? fc::renderJsonSchema(schema)
+                                               : fc::renderPydantic(schema);
+        }
+        std::cout << output;
     } catch (const std::exception& err) {
         std::cerr << "fc.json: " << err.what() << "\n";
         return 1;

--- a/fc.json/render/document.cpp
+++ b/fc.json/render/document.cpp
@@ -1,0 +1,80 @@
+#include "document.hpp"
+
+#include <string>
+
+#include "json_util.hpp"
+
+namespace fc {
+namespace {
+
+// How a leaf (scalar) value is rendered.
+enum class LeafMode { Example, Redact };
+
+std::string ind(int depth) { return std::string(static_cast<std::size_t>(depth) * 2, ' '); }
+
+// Type-illustrative default for a scalar node in example mode.
+std::string exampleLeaf(NodeKind kind) {
+    switch (kind) {
+        case NodeKind::Null:   return "null";
+        case NodeKind::Bool:   return "true";
+        case NodeKind::Int:    return "0";
+        case NodeKind::Float:  return "1.0";
+        case NodeKind::String: return "\"string\"";
+        default:               return "null"; // Object/Array handled by caller
+    }
+}
+
+class DocumentRenderer {
+public:
+    DocumentRenderer(const Tree& tree, LeafMode mode) : tree_(tree), mode_(mode) {}
+
+    std::string run() { return emit(tree_.root, 0) + "\n"; }
+
+private:
+    const Tree& tree_;
+    LeafMode mode_;
+
+    std::string emit(NodeId id, int depth) {
+        const Node& node = tree_.at(id);
+        switch (node.kind) {
+            case NodeKind::Object: return emitObject(node, depth);
+            case NodeKind::Array:  return emitArray(node, depth);
+            default:
+                return mode_ == LeafMode::Redact ? "\"***\"" : exampleLeaf(node.kind);
+        }
+    }
+
+    std::string emitObject(const Node& node, int depth) {
+        if (node.children.empty()) return "{}";
+        std::string out = "{\n";
+        for (std::size_t i = 0; i < node.children.size(); ++i) {
+            const Node& child = tree_.at(node.children[i]);
+            out += ind(depth + 1) + jsonString(child.key) + ": " +
+                   emit(node.children[i], depth + 1);
+            out += (i + 1 < node.children.size()) ? ",\n" : "\n";
+        }
+        return out + ind(depth) + "}";
+    }
+
+    std::string emitArray(const Node& node, int depth) {
+        if (node.children.empty()) return "[]";
+        std::string out = "[\n";
+        for (std::size_t i = 0; i < node.children.size(); ++i) {
+            out += ind(depth + 1) + emit(node.children[i], depth + 1);
+            out += (i + 1 < node.children.size()) ? ",\n" : "\n";
+        }
+        return out + ind(depth) + "]";
+    }
+};
+
+} // namespace
+
+std::string renderExample(const Tree& tree) {
+    return DocumentRenderer(tree, LeafMode::Example).run();
+}
+
+std::string renderRedacted(const Tree& tree) {
+    return DocumentRenderer(tree, LeafMode::Redact).run();
+}
+
+} // namespace fc

--- a/fc.json/render/document.hpp
+++ b/fc.json/render/document.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+// Document renderers: emit a JSON document that mirrors the input structure,
+// * substituting leaf values. Both are pure walks over the ValueIR (no schema
+// * inference needed) and share one emitter. See ADR 0001.
+//   - example: each value becomes a type default (int 0, float 1.0, "string", ...)
+//   - redact:  each value becomes "***"
+
+#include <string>
+
+#include "../ir/node.hpp"
+
+namespace fc {
+
+std::string renderExample(const Tree& tree);
+std::string renderRedacted(const Tree& tree);
+
+} // namespace fc

--- a/fc.json/render/json_util.hpp
+++ b/fc.json/render/json_util.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+// Shared JSON output helpers for renderers that emit JSON (json-schema,
+// example, redact). No rapidjson: hand-built, per the ADR 0001 quarantine.
+
+#include <string>
+
+namespace fc {
+
+// A JSON string literal for an arbitrary key or value. Escapes per JSON rules;
+// control characters below 0x20 use \u00XX. UTF-8 bytes pass through.
+inline std::string jsonString(const std::string& s) {
+    static const char* hex = "0123456789abcdef";
+    std::string out = "\"";
+    for (unsigned char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            case '\b': out += "\\b"; break;
+            case '\f': out += "\\f"; break;
+            default:
+                if (c < 0x20) {
+                    out += "\\u00";
+                    out += hex[(c >> 4) & 0xF];
+                    out += hex[c & 0xF];
+                } else {
+                    out += static_cast<char>(c);
+                }
+        }
+    }
+    return out + "\"";
+}
+
+} // namespace fc

--- a/fc.json/render/jsonschema.cpp
+++ b/fc.json/render/jsonschema.cpp
@@ -3,35 +3,10 @@
 #include <string>
 #include <vector>
 
+#include "json_util.hpp"
+
 namespace fc {
 namespace {
-
-// A JSON string literal for an arbitrary key/value. Escapes per JSON rules;
-// control characters below 0x20 use \u00XX.
-std::string jsonString(const std::string& s) {
-    static const char* hex = "0123456789abcdef";
-    std::string out = "\"";
-    for (unsigned char c : s) {
-        switch (c) {
-            case '"':  out += "\\\""; break;
-            case '\\': out += "\\\\"; break;
-            case '\n': out += "\\n"; break;
-            case '\r': out += "\\r"; break;
-            case '\t': out += "\\t"; break;
-            case '\b': out += "\\b"; break;
-            case '\f': out += "\\f"; break;
-            default:
-                if (c < 0x20) {
-                    out += "\\u00";
-                    out += hex[(c >> 4) & 0xF];
-                    out += hex[c & 0xF];
-                } else {
-                    out += static_cast<char>(c); // UTF-8 bytes pass through
-                }
-        }
-    }
-    return out + "\"";
-}
 
 class JsonSchemaRenderer {
 public:

--- a/fc.json/tests/test_document.cpp
+++ b/fc.json/tests/test_document.cpp
@@ -1,0 +1,63 @@
+#include <doctest/doctest.h>
+
+#include <string>
+
+#include "../parse/parser.hpp"
+#include "../render/document.hpp"
+
+using namespace fc;
+
+namespace {
+
+std::string example(const std::string& json) { return renderExample(parse(json)); }
+std::string redact(const std::string& json) { return renderRedacted(parse(json)); }
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+} // namespace
+
+TEST_CASE("example substitutes type-illustrative defaults per leaf") {
+    std::string out = example(R"({"i":42,"f":3.14,"s":"hi","b":false,"z":null})");
+    CHECK(has(out, R"("i": 0)"));
+    CHECK(has(out, R"("f": 1.0)"));
+    CHECK(has(out, R"("s": "string")"));
+    CHECK(has(out, R"("b": true)"));
+    CHECK(has(out, R"("z": null)"));
+}
+
+TEST_CASE("redact masks every leaf with asterisks, keeps structure") {
+    std::string out = redact(R"({"i":42,"s":"secret","nested":{"k":"v"}})");
+    CHECK(has(out, R"("i": "***")"));
+    CHECK(has(out, R"("s": "***")"));
+    CHECK(has(out, R"("k": "***")"));
+    CHECK(has(out, R"("nested": {)")); // structure preserved
+}
+
+TEST_CASE("both mirror structure: keys, nesting, array element count") {
+    // Two array elements in, two out (faithful mirror, not collapsed).
+    std::string ex = example(R"({"xs":[1,2,3]})");
+    CHECK(has(ex, R"("xs": [)"));
+    // three zeros
+    CHECK(ex.find("0") != std::string::npos);
+    std::string rd = redact(R"({"xs":[1,2]})");
+    // two masked entries
+    std::size_t first = rd.find("\"***\"");
+    std::size_t second = rd.find("\"***\"", first + 1);
+    CHECK(second != std::string::npos);
+}
+
+TEST_CASE("empty object and array round-trip") {
+    CHECK(has(example(R"({"o":{},"a":[]})"), R"("o": {})"));
+    CHECK(has(example(R"({"o":{},"a":[]})"), R"("a": [])"));
+}
+
+TEST_CASE("raw keys are preserved verbatim (no sanitization)") {
+    CHECK(has(redact(R"({"a b":1})"), R"("a b": "***")"));
+}
+
+TEST_CASE("top-level array is handled") {
+    CHECK(has(example("[1,2]"), "["));
+    CHECK(has(redact(R"(["x","y"])"), R"("***")"));
+}


### PR DESCRIPTION
## Summary

- adds `-f example` (values become type defaults: `0`, `1.0`, `"string"`, `true`, `null`)
- adds `-f redact` (every value masked to `"***"`, structure kept)
- both are pure ValueIR walks sharing one JSON emitter; no schema inference

## Why

example and redact are value-views of the input, not schema-views, so they read
the ValueIR directly (structure plus values) rather than going through
SchemaIR. One emitter, two leaf substitutions. Also pulled the JSON string
escaper into a shared header so the json-schema renderer and these don't each
carry their own copy.

## Risk

Low. Default output is unchanged and the new formats are additive. Output
verified as valid JSON on both samples.

## Validation

- `ctest`: 44 cases / 137 assertions pass
- example and redact on both samples emit valid JSON (python json.load)

## Follow-up

- table renderer (PR-C, brings `tabulate` back)
- issue #8 (signature delimiter hardening) remains open, unrelated
