### PR TITLE
feat(cli): table output format via tabulate

### DIFF
--- a/.rctx/claims/build/deps-via-vcpkg.md
+++ b/.rctx/claims/build/deps-via-vcpkg.md
@@ -10,8 +10,8 @@ in `vcpkg.json` with a pinned `builtin-baseline` for reproducibility (see
 ADR 0002). There are **no vendored third-party source trees** in the repo, and
 includes are system-style (`#include <rapidjson/...>`, `<argparse/...>`).
 
-Current declared deps: `rapidjson`, `argparse`, and `doctest` (test-only).
-`tabulate` returns to the manifest when the `--table` renderer is implemented.
+Current declared deps: `rapidjson`, `argparse`, `tabulate` (table renderer),
+and `doctest` (test-only).
 
 **Why it matters:** a contributor must configure with the vcpkg toolchain
 (`-DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake`, wired via

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Dependencies come from vcpkg (manifest mode). See ADR 0002.
 find_package(RapidJSON CONFIG REQUIRED)  # header-only: sets RAPIDJSON_INCLUDE_DIRS
 find_package(argparse CONFIG REQUIRED)   # target: argparse::argparse
+find_package(tabulate CONFIG REQUIRED)   # target: tabulate::tabulate
 
 # Core library: parse adapter + IR. rapidjson is confined to parser.cpp, so it
 # is a PRIVATE include of the core and never leaks to consumers. See ADR 0001.
@@ -17,8 +18,10 @@ add_library(fc-json-core STATIC
   fc.json/render/pydantic.cpp
   fc.json/render/jsonschema.cpp
   fc.json/render/document.cpp
+  fc.json/render/table.cpp
 )
 target_include_directories(fc-json-core PRIVATE ${RAPIDJSON_INCLUDE_DIRS})
+target_link_libraries(fc-json-core PRIVATE tabulate::tabulate)
 
 # The executable no longer touches rapidjson — it is fully behind the core
 # library's parse adapter, so no rapidjson include here. See ADR 0001.
@@ -35,6 +38,7 @@ add_executable(fc-json-tests
   fc.json/tests/test_render.cpp
   fc.json/tests/test_jsonschema.cpp
   fc.json/tests/test_document.cpp
+  fc.json/tests/test_table.cpp
 )
 target_link_libraries(fc-json-tests PRIVATE doctest::doctest fc-json-core)
 add_test(NAME fc-json-tests COMMAND fc-json-tests)

--- a/fc.json/main.cpp
+++ b/fc.json/main.cpp
@@ -17,6 +17,7 @@
 #include "render/pydantic.hpp"
 #include "render/jsonschema.hpp"
 #include "render/document.hpp"
+#include "render/table.hpp"
 
 namespace {
 
@@ -44,7 +45,7 @@ int main(int argc, char* argv[]) {
 
     std::string format;
     parser.add_argument("-f", "--format")
-        .help("output format: pydantic (default), json-schema, example, redact")
+        .help("output format: pydantic (default), json-schema, example, redact, table")
         .default_value(std::string("pydantic"))
         .store_into(format);
 
@@ -58,9 +59,9 @@ int main(int argc, char* argv[]) {
     // Validated here rather than via argparse .choices() so a bad value gets a
     // clear message instead of argparse's misleading positional-count error.
     if (format != "pydantic" && format != "json-schema" &&
-        format != "example" && format != "redact") {
+        format != "example" && format != "redact" && format != "table") {
         std::cerr << "fc.json: unknown format '" << format
-                  << "' (expected: pydantic, json-schema, example, redact)\n";
+                  << "' (expected: pydantic, json-schema, example, redact, table)\n";
         return 1;
     }
 
@@ -75,8 +76,13 @@ int main(int argc, char* argv[]) {
             output = fc::renderRedacted(tree);
         } else {
             const fc::SchemaModule schema = fc::inferSchema(tree);
-            output = (format == "json-schema") ? fc::renderJsonSchema(schema)
-                                               : fc::renderPydantic(schema);
+            if (format == "json-schema") {
+                output = fc::renderJsonSchema(schema);
+            } else if (format == "table") {
+                output = fc::renderTable(schema);
+            } else {
+                output = fc::renderPydantic(schema);
+            }
         }
         std::cout << output;
     } catch (const std::exception& err) {

--- a/fc.json/render/table.cpp
+++ b/fc.json/render/table.cpp
@@ -1,0 +1,85 @@
+#include "table.hpp"
+
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <tabulate/table.hpp> // aggregate tabulate.hpp is only a banner in vcpkg
+
+namespace fc {
+namespace {
+
+// Compact, neutral type label for a cell. Optionality is shown on the path
+// (a trailing "?"), so it is not encoded here.
+std::string typeLabel(const SchemaModule& mod, const TypeRef& t) {
+    switch (t.kind) {
+        case TypeKind::Null:    return "None";
+        case TypeKind::Bool:    return "bool";
+        case TypeKind::Int:     return "int";
+        case TypeKind::Float:   return "float";
+        case TypeKind::String:  return "str";
+        case TypeKind::Unknown: return "Any";
+        case TypeKind::Object:  return mod.at(t.objectSchema).name;
+        case TypeKind::List:    return "list[" + typeLabel(mod, t.args.front()) + "]";
+        case TypeKind::Union: {
+            std::string s = "Union[";
+            for (std::size_t i = 0; i < t.args.size(); ++i) {
+                if (i) s += ", ";
+                s += typeLabel(mod, t.args[i]);
+            }
+            return s + "]";
+        }
+    }
+    return "Any";
+}
+
+class TableBuilder {
+public:
+    explicit TableBuilder(const SchemaModule& mod) : mod_(mod) {}
+
+    std::vector<std::pair<std::string, std::string>> rows() {
+        if (mod_.root.kind == TypeKind::Object) {
+            expand("", mod_.root);
+        } else {
+            rows_.emplace_back("(root)", typeLabel(mod_, mod_.root));
+            expand("", mod_.root);
+        }
+        return std::move(rows_);
+    }
+
+private:
+    const SchemaModule& mod_;
+    std::vector<std::pair<std::string, std::string>> rows_;
+
+    // Emit a row per field, then descend into nested objects (and objects that
+    // are the element of a list, tagged with "[]").
+    void expand(const std::string& path, const TypeRef& t) {
+        if (t.kind == TypeKind::Object) {
+            for (const Field& f : mod_.at(t.objectSchema).fields) {
+                const std::string p = path.empty() ? f.key : path + "." + f.key;
+                rows_.emplace_back(p + (f.optional ? "?" : ""), typeLabel(mod_, f.type));
+                expand(p, f.type);
+            }
+        } else if (t.kind == TypeKind::List && t.args.front().kind == TypeKind::Object) {
+            expand(path + "[]", t.args.front());
+        }
+    }
+};
+
+} // namespace
+
+std::string renderTable(const SchemaModule& mod) {
+    tabulate::Table table;
+    table.add_row({"Path", "Type"});
+    for (auto& [path, type] : TableBuilder(mod).rows()) {
+        table.add_row({path, type});
+    }
+    table[0].format().font_style({tabulate::FontStyle::bold});
+
+    std::ostringstream out;
+    out << table << "\n";
+    return out.str();
+}
+
+} // namespace fc

--- a/fc.json/render/table.hpp
+++ b/fc.json/render/table.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+// Table renderer: SchemaIR -> a path/type overview table.
+// * Pure over the SchemaIR. The formatting is done by the tabulate library
+// * (confined to table.cpp); this header exposes no vendor type. See ADR 0001.
+
+#include <string>
+
+#include "../ir/schema.hpp"
+
+namespace fc {
+
+std::string renderTable(const SchemaModule& mod);
+
+} // namespace fc

--- a/fc.json/tests/test_table.cpp
+++ b/fc.json/tests/test_table.cpp
@@ -1,0 +1,52 @@
+#include <doctest/doctest.h>
+
+#include <string>
+
+#include "../parse/parser.hpp"
+#include "../render/table.hpp"
+#include "../schema/infer.hpp"
+
+using namespace fc;
+
+namespace {
+
+std::string table(const std::string& json) {
+    return renderTable(inferSchema(parse(json)));
+}
+
+bool has(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+
+} // namespace
+
+TEST_CASE("table has a header and one row per field") {
+    std::string out = table(R"({"a":{"b":"x"},"n":1})");
+    CHECK(has(out, "Path"));
+    CHECK(has(out, "Type"));
+    CHECK(has(out, "n"));   // scalar field
+    CHECK(has(out, "int"));
+}
+
+TEST_CASE("nested objects expand to dotted paths") {
+    std::string out = table(R"({"a":{"b":"x"}})");
+    CHECK(has(out, "a.b")); // nested path
+    CHECK(has(out, "A"));   // a's type is the class name
+    CHECK(has(out, "str"));
+}
+
+TEST_CASE("optional fields are marked with ? on the path") {
+    std::string out = table(R"({"list":[{"a":1},{"a":1,"b":2}]})");
+    CHECK(has(out, "list[].a"));  // element field, list-expanded
+    CHECK(has(out, "list[].b?")); // optional element field
+}
+
+TEST_CASE("union type is shown as a label") {
+    CHECK(has(table(R"({"d":[1,"x"]})"), "list[Union[int, str]]"));
+}
+
+TEST_CASE("top-level array shows a (root) row") {
+    std::string out = table(R"([{"a":1}])");
+    CHECK(has(out, "(root)"));
+    CHECK(has(out, "list[RootItem]"));
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
   "dependencies": [
     "rapidjson",
     "argparse",
-    "doctest"
+    "doctest",
+    "tabulate"
   ]
 }


### PR DESCRIPTION
## Summary

- adds `-f table`: a path/type overview of the JSON, rendered by tabulate
- we flatten the SchemaIR into (path, type) rows; tabulate does all the formatting

## Why

Last of the step-5 renderers. We only build the rows (dotted paths, nested
objects and list-of-object elements expanded with `[]`, optional fields marked
`?`); tabulate handles borders, alignment, and sizing, so none of the display
is hand-built. tabulate stays confined to table.cpp, with no vendor type in the
header.

## Risk

Low. Default output is unchanged and the format is additive. One packaging note:
vcpkg's `tabulate/tabulate.hpp` is only a license banner, so we include
`tabulate/table.hpp` directly.

## Validation

- `ctest`: 49 cases / 149 assertions pass
- table output verified on both samples

## Follow-up

- issue #8 (signature delimiter hardening) remains open, unrelated
