### PR TITLE
ci: build and test on every push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+          - runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build prerequisites (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build pkg-config
+
+      - name: Install vcpkg
+        run: |
+          set -euo pipefail
+          VCPKG_ROOT="${RUNNER_TEMP}/vcpkg"
+          VCPKG_COMMIT="$(awk -F'"' '/builtin-baseline/ { print $4 }' vcpkg.json)"
+          git clone --depth 1 https://github.com/microsoft/vcpkg.git "${VCPKG_ROOT}"
+          git -C "${VCPKG_ROOT}" fetch --depth 1 origin "${VCPKG_COMMIT}"
+          git -C "${VCPKG_ROOT}" checkout "${VCPKG_COMMIT}"
+          "${VCPKG_ROOT}/bootstrap-vcpkg.sh" -disableMetrics
+          echo "VCPKG_ROOT=${VCPKG_ROOT}" >> "${GITHUB_ENV}"
+
+      - name: Configure and build (with tests)
+        run: |
+          cmake -S . -B build/ci \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+            -DFC_JSON_BUILD_TESTS=ON
+          cmake --build build/ci
+
+      - name: Run tests
+        run: ctest --test-dir build/ci --output-on-failure


### PR DESCRIPTION
## Summary

- Add ci.yml: build and run the test suite on push to main and on every PR,
  across an Ubuntu + macOS matrix. Mirrors the rctx CI (vcpkg pinned to the
  manifest baseline, Debug build with tests, ctest).
- Closes the gap where only tag pushes were built, so PRs had no automated check.

## Validation

- Ran the exact job steps locally (macOS) with VCPKG_ROOT=<vcpkg-root>: Debug
  configure, build, and `ctest` pass 1/1. The macOS build path is the same one
  the 2.0.1 release job already exercised on the GitHub macOS runner.

## Follow-up

- Format and lint in CI (clang-format --dry-run --Werror, clang-tidy) as
  CONVENTIONS describes, once .clang-format and .clang-tidy are committed.
  Neither file exists in the repo yet, so it is out of scope here.
